### PR TITLE
Frontend Perceived Performance

### DIFF
--- a/frontend/src/pages/finder/common/KitaDataContext.tsx
+++ b/frontend/src/pages/finder/common/KitaDataContext.tsx
@@ -60,9 +60,12 @@ const KitaListContextProvider: React.FC<KitaListContextProviderProps> = ({
     setIsFetching(true);
     setKitas(null);
 
-    const foundKitas = await loader({ ...latlng });
-    setKitas(foundKitas);
-    setIsFetching(false);
+    //TODO: Review impact, experimental instant-delay to allow animations to fade out before fetching
+    setTimeout(async () => {
+      const foundKitas = await loader({ ...latlng });
+      setKitas(foundKitas);
+      setIsFetching(false);
+    }, 0);
   };
 
   return (

--- a/frontend/src/pages/finder/common/Map/KitaMap.tsx
+++ b/frontend/src/pages/finder/common/Map/KitaMap.tsx
@@ -63,7 +63,7 @@ const KitaMap: React.FC<KitaMapProps> = ({
       <Map
         id="finderMap" // used to find the map with useMap(), if you remove this the programmatic control won't work
         reuseMaps
-        // TODO: move this to an env once we separate dev and prod map keys
+        //TODO: move this to an env once we separate dev and prod map keys
         mapboxAccessToken="pk.eyJ1IjoiaGFubm9ncmltbSIsImEiOiJjbGdtamwyZHowNmxnM2VxbTd6eHZhMjExIn0.0wHQJStc2kgDh29Ewv_g-w"
         style={{ width: "100%", height: "100%" }}
         mapStyle="mapbox://styles/mapbox/streets-v9"


### PR DESCRIPTION
Working on #40, no low-hanging changes are available to improve the map+list experience on the frontend side without sacrificing data intentionally (showing less than is available in 3km).

I have implemented an experimental change to the logic order during the fetch event so that the list animation does not get stuck in the middle of the fetch. I hope this will improve perceived performance, even if it ever so slightly even delays the fetch.

Closing #40 with this PR.