### PR TITLE
Adjusted Email signup endpoints 

### DIFF
--- a/backend/src/entities/signups/handler/kitaFinderServiceSignup.ts
+++ b/backend/src/entities/signups/handler/kitaFinderServiceSignup.ts
@@ -12,12 +12,9 @@ import { EmailSignup } from "../service";
 
 interface IKitaFinderServiceSignup {
   email: string;
-  consentId: string;
   fullAddress: string;
   desiredStartingMonth: string;
   actualOrExpectedBirthMonth: string;
-  createdAt: string;
-  consentedAt: string;
   revokedAt?: string | null;
 }
 class KitaFinderServiceSignupValidator {
@@ -27,10 +24,6 @@ class KitaFinderServiceSignupValidator {
 
   @IsString()
   @IsNotEmpty()
-  consentId: string;
-
-  @IsString()
-  @IsNotEmpty()
   fullAddress: string;
 
   @IsString()
@@ -40,14 +33,6 @@ class KitaFinderServiceSignupValidator {
   @IsString()
   @IsNotEmpty()
   actualOrExpectedBirthMonth: string;
-
-  @IsDateString()
-  @IsNotEmpty()
-  createdAt: string;
-
-  @IsDateString()
-  @IsNotEmpty()
-  consentedAt: string;
 
   @IsOptional()
   @IsDateString()
@@ -66,22 +51,16 @@ export const validator: RequestHandler<IKitaFinderServiceSignup> = async (
   try {
     const {
       email,
-      consentId,
       fullAddress,
       desiredStartingMonth,
       actualOrExpectedBirthMonth,
-      createdAt,
-      consentedAt,
       revokedAt,
     } = req.body;
     const newServiceSignup = new KitaFinderServiceSignupValidator();
     newServiceSignup.email = email;
-    newServiceSignup.consentId = consentId;
     newServiceSignup.fullAddress = fullAddress;
     newServiceSignup.desiredStartingMonth = desiredStartingMonth;
     newServiceSignup.actualOrExpectedBirthMonth = actualOrExpectedBirthMonth;
-    newServiceSignup.createdAt = createdAt;
-    newServiceSignup.consentedAt = consentedAt;
     newServiceSignup.revokedAt = revokedAt;
     const errors = await validate(newServiceSignup);
 
@@ -98,23 +77,17 @@ const handler: RequestHandler<IKitaFinderServiceSignup> = async (req, res) => {
   try {
     const {
       email,
-      consentId,
       fullAddress,
       desiredStartingMonth,
       actualOrExpectedBirthMonth,
-      createdAt,
-      consentedAt,
       revokedAt,
     } = req.body;
 
     await EmailSignup.kitaFinderServiceSignup(
       email,
-      consentId,
       fullAddress,
       desiredStartingMonth,
       actualOrExpectedBirthMonth,
-      createdAt,
-      consentedAt,
       revokedAt
     );
 

--- a/backend/src/entities/signups/handler/singleKitaNotificationSignup.ts
+++ b/backend/src/entities/signups/handler/singleKitaNotificationSignup.ts
@@ -1,22 +1,13 @@
 import { RequestHandler } from "express";
-import {
-  IsDateString,
-  IsEmail,
-  IsNotEmpty,
-  IsString,
-  validate,
-} from "class-validator";
+import { IsEmail, IsNotEmpty, IsString, validate } from "class-validator";
 import logger from "../../../logger";
 import { EmailSignup } from "../service";
 
 interface ISingleKitaNotification {
   email: string;
-  consentId: string;
   kitaId: string;
   kitaName: string;
   kitaDesiredAvailability: string;
-  createdAt: string;
-  consentedAt: string;
 }
 
 class SingleKitaNotificationValidator {
@@ -26,10 +17,6 @@ class SingleKitaNotificationValidator {
 
   @IsString()
   @IsNotEmpty()
-  consentId: string;
-
-  @IsString()
-  @IsNotEmpty()
   kitaId: string;
 
   @IsString()
@@ -39,14 +26,6 @@ class SingleKitaNotificationValidator {
   @IsString()
   @IsNotEmpty()
   kitaDesiredAvailability: string;
-
-  @IsDateString()
-  @IsNotEmpty()
-  createdAt: string;
-
-  @IsDateString()
-  @IsNotEmpty()
-  consentedAt: string;
 }
 
 export const validator: RequestHandler<ISingleKitaNotification> = async (
@@ -59,23 +38,12 @@ export const validator: RequestHandler<ISingleKitaNotification> = async (
   }
 
   try {
-    const {
-      email,
-      consentId,
-      kitaId,
-      kitaDesiredAvailability,
-      kitaName,
-      createdAt,
-      consentedAt,
-    } = req.body;
+    const { email, kitaId, kitaDesiredAvailability, kitaName } = req.body;
     const newNotification = new SingleKitaNotificationValidator();
     newNotification.email = email;
-    newNotification.consentId = consentId;
     newNotification.kitaId = kitaId;
     newNotification.kitaDesiredAvailability = kitaDesiredAvailability;
     newNotification.kitaName = kitaName;
-    newNotification.createdAt = createdAt;
-    newNotification.consentedAt = consentedAt;
 
     const errors = await validate(newNotification);
     if (errors.length) return res.status(400).json({ error: errors });
@@ -89,24 +57,13 @@ export const validator: RequestHandler<ISingleKitaNotification> = async (
 
 const handler: RequestHandler<ISingleKitaNotification> = async (req, res) => {
   try {
-    const {
-      email,
-      consentId,
-      kitaId,
-      kitaDesiredAvailability,
-      kitaName,
-      createdAt,
-      consentedAt,
-    } = req.body;
+    const { email, kitaId, kitaDesiredAvailability, kitaName } = req.body;
 
     await EmailSignup.singleKitaNotificationSignup(
       email,
-      consentId,
       kitaId,
       kitaDesiredAvailability,
-      kitaName,
-      createdAt,
-      consentedAt
+      kitaName
     );
 
     return res.status(200).send();

--- a/backend/src/entities/signups/model.ts
+++ b/backend/src/entities/signups/model.ts
@@ -1,4 +1,5 @@
 import mongoose, { Schema, Document } from "mongoose";
+import { v4 as uuidv4 } from "uuid";
 
 interface IUser extends Document {
   id: string;
@@ -13,20 +14,23 @@ interface IUser extends Document {
   consentedAt: string;
 }
 
-const UserSchema: Schema = new Schema({
-  id: { type: String, required: true },
-  email: { type: String, required: true },
-  consentId: { type: String, required: true },
-  trackedKitas: [
-    {
-      id: { type: String, required: true },
-      kitaName: { type: String, required: true },
-      kitaAvailability: { type: String, required: true },
-    },
-  ],
-  createdAt: { type: String, required: true },
-  consentedAt: { type: String, required: true },
-});
+const UserSchema: Schema = new Schema(
+  {
+    id: { type: String, required: true },
+    email: { type: String, required: true },
+    consentId: { type: String, default: uuidv4(), required: true },
+    trackedKitas: [
+      {
+        id: { type: String, required: true },
+        kitaName: { type: String, required: true },
+        kitaAvailability: { type: String, required: true },
+      },
+    ],
+    createdAt: { type: String, default: Date.now, required: true },
+    consentedAt: { type: String, default: Date.now, required: true },
+  },
+  { timestamps: true }
+);
 
 const UserModel = mongoose.model<IUser>("user", UserSchema);
 
@@ -46,10 +50,7 @@ const EmailServiceSignupSchema: Schema = new Schema({
     type: String,
     required: true,
   },
-  consentId: {
-    type: String,
-    required: true,
-  },
+  consentId: { type: String, default: uuidv4(), required: true },
   fullAddress: {
     type: String,
     required: true,
@@ -62,14 +63,8 @@ const EmailServiceSignupSchema: Schema = new Schema({
     type: String,
     required: true,
   },
-  createdAt: {
-    type: String,
-    required: true,
-  },
-  consentedAt: {
-    type: String,
-    required: true,
-  },
+  createdAt: { type: String, default: Date.now, required: true },
+  consentedAt: { type: String, default: Date.now, required: true },
   revokedAt: {
     type: String,
     default: null,

--- a/backend/src/entities/signups/service.ts
+++ b/backend/src/entities/signups/service.ts
@@ -5,19 +5,15 @@ import { v4 as uuidv4 } from "uuid";
 export class EmailSignup {
   public static singleKitaNotificationSignup = async (
     email: string,
-    consentId: string,
     kitaId: string,
     kitaDesiredAvailability: string,
-    kitaName: string,
-    createdAt: string,
-    consentedAt: string
+    kitaName: string
   ) => {
     try {
       // needs logic if user already exists but then MongoDB triggers might have to be adjusted aswell
       await UserModel.create({
         id: uuidv4(),
         email,
-        consentId,
         trackedKitas: [
           {
             id: kitaId,
@@ -25,8 +21,6 @@ export class EmailSignup {
             kitaAvailability: kitaDesiredAvailability,
           },
         ],
-        createdAt,
-        consentedAt,
       });
       logger.info(`User ${email} signed up for ${kitaName} with id ${kitaId}`);
       return;
@@ -37,12 +31,9 @@ export class EmailSignup {
   };
   public static kitaFinderServiceSignup = async (
     email: string,
-    consentId: string,
     fullAddress: string,
     desiredStartingMonth: string,
     actualOrExpectedBirthMonth: string,
-    createdAt: string,
-    consentedAt: string,
     revokedAt: string | null
   ) => {
     try {
@@ -50,12 +41,9 @@ export class EmailSignup {
       await EmailServiceSignupModel.create({
         id: uuidv4(),
         email,
-        consentId,
         fullAddress,
         desiredStartingMonth,
         actualOrExpectedBirthMonth,
-        createdAt,
-        consentedAt,
         revokedAt,
       });
       logger.info(`User ${email} signed up for kita finder service`);


### PR DESCRIPTION
MongoDB should create a now timestamp for this:
```
  @IsDateString()
  @IsNotEmpty()
  createdAt: string;
  @IsDateString()
  @IsNotEmpty()
  consentedAt: string;


```

```
consentId

Should be UUID created in the backend 
should not be send from frontend aswell as the above 
done for both endpoints
```