### PR TITLE
Updated data fetching process

### DIFF
--- a/backend/src/entities/kitas/model.ts
+++ b/backend/src/entities/kitas/model.ts
@@ -1,107 +1,90 @@
-import mongoose from "mongoose";
+import { Schema, Document, model } from "mongoose";
 
-const KitaDetailSchema = new mongoose.Schema({
-  uuid: {
-    type: String,
-    required: true,
-    unique: false,
-  },
-  name: {
-    type: String,
-    required: true,
-  },
-  number: {
-    type: String,
-    required: true,
-  },
+interface IKitaDetail extends Document {
+  uuid: string;
+  name: string;
+  number: string;
   location: {
-    type: {
-      type: String,
-      enum: ["Point"],
-      required: true,
-    },
-    coordinates: {
-      type: [Number],
-      required: true,
-    },
-  },
+    type: string;
+    coordinates: number[];
+  };
   address: {
-    street: {
-      type: String,
-      required: true,
-    },
-    houseNumber: {
-      type: String,
-      required: true,
-    },
-    zip: {
-      type: String,
-      required: true,
-    },
-    city: {
-      type: String,
-      required: true,
-    },
-  },
-  availability: {
-    type: Map,
-    of: Boolean,
-    required: true,
-  },
-  imageUrl: {
-    type: String,
-    required: true,
-  },
+    street: string;
+    houseNumber: string;
+    zip: string;
+    city: string;
+  };
+  availability: Map<string, boolean>;
+  imageUrl: string;
   capacity: {
-    total: {
-      type: Number,
-      required: true,
-    },
-    underThree: {
-      type: Number,
-      required: true,
-    },
-  },
-  minimumAcceptanceAgeInMonths: {
-    type: Number,
-    required: true,
-  },
+    total: number;
+    underThree: number;
+  };
+  minimumAcceptanceAgeInMonths: number;
   contactDetails: {
-    email: String,
-    phone: String,
-    website: String,
-  },
-  openingHours: {
-    type: Map,
-    of: {
-      from: String,
-      to: String,
-    },
-    required: true,
-  },
+    email?: string;
+    phone?: string;
+    website?: string;
+  };
+  openingHours: Map<string, { from: string; to: string }>;
   approach: {
-    pedagogicalConcepts: [String],
-    emphasis: [String],
-    languages: [String],
-    mixedAgesDescriptions: [String],
-  },
-  foundingDate: {
-    type: String,
-    required: true,
-  },
-  closingDate: {
-    type: String,
-  },
-  version: {
-    type: String,
-    required: true,
-  },
-  checkSum: {
-    type: String,
-    required: true,
-  },
-});
+    pedagogicalConcepts: string[];
+    emphasis: string[];
+    languages: string[];
+    mixedAgesDescriptions: string[];
+  };
+  foundingDate: string;
+  closingDate?: string;
+  version: string;
+  checkSum: string;
+}
 
-const KitaDetailModel = mongoose.model("KitaDetail", KitaDetailSchema);
+const KitaDetailSchema = new Schema<IKitaDetail>(
+  {
+    uuid: { type: String, required: true },
+    name: { type: String, required: true },
+    number: { type: String, required: true },
+    location: {
+      type: { type: String, enum: ["Point"], required: true },
+      coordinates: { type: [Number], required: true },
+    },
+    address: {
+      street: { type: String, required: true },
+      houseNumber: { type: String, required: true },
+      zip: { type: String, required: true },
+      city: { type: String, required: true },
+    },
+    availability: { type: Map, of: Boolean, required: true },
+    imageUrl: { type: String, required: true },
+    capacity: {
+      total: { type: Number, required: true },
+      underThree: { type: Number, required: true },
+    },
+    minimumAcceptanceAgeInMonths: { type: Number, required: true },
+    contactDetails: {
+      email: String,
+      phone: String,
+      website: String,
+    },
+    openingHours: {
+      type: Map,
+      of: { from: String, to: String },
+      required: true,
+    },
+    approach: {
+      pedagogicalConcepts: [String],
+      emphasis: [String],
+      languages: [String],
+      mixedAgesDescriptions: [String],
+    },
+    foundingDate: { type: String, required: true },
+    closingDate: { type: String },
+    version: { type: String, required: true },
+    checkSum: { type: String, required: true },
+  },
+  { timestamps: true }
+);
+
+const KitaDetailModel = model<IKitaDetail>("KitaDetail", KitaDetailSchema);
 
 export default KitaDetailModel;

--- a/backend/src/entities/kitas/service.ts
+++ b/backend/src/entities/kitas/service.ts
@@ -2,6 +2,7 @@ import KitaDetailModel from "./model";
 import { Kita } from "../../types";
 import paginate, { PaginatedResultsResponse } from "../../utils/paginate";
 import logger from "../../logger";
+import getLatestDataVersion from "../../utils/getLatestDataVersion";
 
 /**
  * The KitaService class provides methods to interact with Kita data.
@@ -26,6 +27,8 @@ class KitaService {
     limit: number
   ): Promise<PaginatedResultsResponse<Kita>> => {
     try {
+      const latestVersion = await getLatestDataVersion();
+
       const nearestSortedKitaList = await KitaDetailModel.find({
         location: {
           $nearSphere: {
@@ -36,7 +39,7 @@ class KitaService {
             $maxDistance: radius, // in meter
           },
         },
-        version: process.env.CURRENT_KITA_DATA_VERSION,
+        version: latestVersion,
       }).limit(50);
       const paginatedKitas = paginate(nearestSortedKitaList, page, limit);
 

--- a/backend/src/utils/getLatestDataVersion.ts
+++ b/backend/src/utils/getLatestDataVersion.ts
@@ -1,0 +1,20 @@
+import KitaDetailModel from "../entities/kitas/model";
+
+async function getLatestDataVersion() {
+  try {
+    const latestVersionDoc = await KitaDetailModel.findOne(
+      {},
+      {},
+      { sort: { version: -1 } }
+    ).lean();
+    if (!latestVersionDoc) {
+      return "0";
+    }
+    return latestVersionDoc.version;
+  } catch (error) {
+    console.error("Error fetching latest version:", error);
+    throw error;
+  }
+}
+
+export default getLatestDataVersion;

--- a/backend/src/utils/validateEnv.ts
+++ b/backend/src/utils/validateEnv.ts
@@ -1,6 +1,5 @@
 const requiredEnvVariables = [
   "AWS_KMS_KEY_ID",
-  "CURRENT_KITA_DATA_VERSION",
   "API_KEY",
   "AUTH_KEY",
   "AWS_ACCESS_KEY_ID",


### PR DESCRIPTION
The Scraper now fetches data and adds it with a dynamic version number to the database.

To test: 

Start the backend and make a request.
GET http://localhost:3000/scrape

In the database:
https://cloud.mongodb.com/v2/64417c194d775c4fb22e5833#/metrics/replicaSet/64417c3c94d95515db77c51b/explorer/realData/kitadetails/find

You can filter:
{version: "3"}, {version: "4"} etc.. and see if the new version is there.


-------
I also created a CronJob that will call this endpoint once a day using a API-Key for authentication. 
The Cronjob will be in action once it is on Dev. 
If it works on Dev i will activate it for Main.

Link to Lambda / CronJob ( https://eu-central-1.console.aws.amazon.com/lambda/home?region=eu-central-1#/functions/runScraper?code&tab=code )