### PR TITLE
fix: Add ACM permissions to GitHub Actions IAM role

### DIFF
--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -218,6 +218,20 @@ resource "aws_iam_role_policy" "github_actions_terraform_infra" {
         ]
         Resource = "*"
       },
+      # ACM permissions (required for CloudFront certificates in us-east-1)
+      {
+        Effect = "Allow"
+        Action = [
+          "acm:RequestCertificate",
+          "acm:DescribeCertificate",
+          "acm:DeleteCertificate",
+          "acm:ListCertificates",
+          "acm:AddTagsToCertificate",
+          "acm:RemoveTagsFromCertificate",
+          "acm:ListTagsForCertificate"
+        ]
+        Resource = "*"
+      },
       # CloudWatch Logs permissions
       {
         Effect = "Allow"


### PR DESCRIPTION
## Summary

This PR adds ACM (AWS Certificate Manager) permissions to the GitHub Actions IAM role, which is required for creating SSL/TLS certificates for CloudFront.

## Context

This fix was needed after PR #127 merged. The terraform apply workflow failed because the GitHub Actions role lacked permission to create ACM certificates.

## Changes

Added ACM permissions to the GitHub Actions terraform infrastructure policy:
- acm:RequestCertificate
- acm:DescribeCertificate
- acm:DeleteCertificate
- acm:ListCertificates
- acm:AddTagsToCertificate
- acm:RemoveTagsFromCertificate
- acm:ListTagsForCertificate

## Notes

- IAM policy already applied to AWS manually via targeted terraform apply
- This PR updates the code to match the AWS state
- Allows workflow re-runs to succeed

Related to #125