### PR TITLE
feat: Add HTTPS custom domain support for dev environment

### DIFF
--- a/.github/workflows/terraform-dev.yml
+++ b/.github/workflows/terraform-dev.yml
@@ -1,6 +1,12 @@
 name: Terraform Deploy (Dev)
 
 on:
+  pull_request:
+    branches:
+      - dev
+    paths:
+      - 'terraform/**'
+      - '.github/workflows/terraform-dev.yml'
   push:
     branches:
       - dev
@@ -15,8 +21,95 @@ permissions:
   pull-requests: write
 
 jobs:
-  terraform:
+  terraform-plan:
+    name: Terraform Plan
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    environment: dev
+
+    defaults:
+      run:
+        working-directory: terraform/environments/dev
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.13.1
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: eu-central-1
+
+      - name: Set Terraform Variables
+        run: |
+          echo "TF_VAR_mongodb_connection_string=${{ secrets.MONGODB_CONNECTION_STRING }}" >> $GITHUB_ENV
+          echo "TF_VAR_api_key=${{ secrets.API_KEY }}" >> $GITHUB_ENV
+          echo "TF_VAR_auth_key=${{ secrets.AUTH_KEY }}" >> $GITHUB_ENV
+          echo "TF_VAR_kita_api_url=${{ secrets.KITA_API_URL }}" >> $GITHUB_ENV
+
+      - name: Terraform Format Check
+        id: fmt
+        run: terraform fmt -check -recursive
+        continue-on-error: true
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan -no-color
+        continue-on-error: true
+
+      - name: Comment PR with Plan
+        uses: actions/github-script@v7
+        if: github.event_name == 'pull_request'
+        env:
+          PLAN: ${{ steps.plan.outputs.stdout }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+            #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+
+            <details><summary>Show Plan</summary>
+
+            \`\`\`terraform
+            ${process.env.PLAN}
+            \`\`\`
+
+            </details>
+
+            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Workflow: \`${{ github.workflow }}\`*`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+
+      - name: Plan Status
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
+  terraform-apply:
+    name: Terraform Apply
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     environment: dev
 
     defaults:

--- a/.github/workflows/terraform-dev.yml
+++ b/.github/workflows/terraform-dev.yml
@@ -69,17 +69,20 @@ jobs:
 
       - name: Terraform Plan
         id: plan
-        run: terraform plan -no-color
+        run: |
+          terraform plan -no-color 2>&1 | tee plan-output.txt
+          echo "exitcode=${PIPESTATUS[0]}" >> $GITHUB_OUTPUT
         continue-on-error: true
 
       - name: Comment PR with Plan
         uses: actions/github-script@v7
         if: github.event_name == 'pull_request'
-        env:
-          PLAN: ${{ steps.plan.outputs.stdout }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const fs = require('fs');
+            const planOutput = fs.readFileSync('terraform/environments/dev/plan-output.txt', 'utf8');
+
             const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
             #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
             #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
@@ -88,7 +91,7 @@ jobs:
             <details><summary>Show Plan</summary>
 
             \`\`\`terraform
-            ${process.env.PLAN}
+            ${planOutput}
             \`\`\`
 
             </details>
@@ -103,7 +106,7 @@ jobs:
             })
 
       - name: Plan Status
-        if: steps.plan.outcome == 'failure'
+        if: steps.plan.outputs.exitcode != '0'
         run: exit 1
 
   terraform-apply:

--- a/docs/Domain-Setup-Guide.md
+++ b/docs/Domain-Setup-Guide.md
@@ -1,0 +1,363 @@
+# Domain Setup Guide: kitaplatz-zentrale.de
+
+This guide walks you through reconnecting the domain `kitaplatz-zentrale.de` to the CloudFront distribution.
+
+## Overview
+
+- **Domain**: `kitaplatz-zentrale.de` (+ `www.kitaplatz-zentrale.de`)
+- **Domain Management Account**: `216360990183` (management account)
+- **CloudFront Account**: `441104482452` (kpz-dev)
+- **Current CloudFront URL**: https://d2qust00jepj31.cloudfront.net
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Management Account (216360990183)                              │
+│  - Route53 Hosted Zone                                          │
+│  - DNS Validation Records (for ACM)                             │
+│  - A/AAAA Records → CloudFront                                  │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              │ DNS Validation
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  KPZ-Dev Account (441104482452)                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │  ACM Certificate (us-east-1)                              │  │
+│  │  - kitaplatz-zentrale.de                                  │  │
+│  │  - www.kitaplatz-zentrale.de                              │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                              │                                   │
+│                              ▼                                   │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │  CloudFront Distribution (Global)                         │  │
+│  │  - Custom domains: kitaplatz-zentrale.de                  │  │
+│  │  - Origin: S3 bucket (kpz-frontend-dev)                   │  │
+│  └───────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Prerequisites
+
+- AWS CLI configured with two profiles:
+  - `kpz-dev` (account 441104482452)
+  - `anthony-management` (account 216360990183)
+- Terraform 1.13.1
+- Access to domain registrar for nameserver updates
+
+## Step-by-Step Setup
+
+### Step 1: Request ACM Certificate (Terraform - kpz-dev account)
+
+The ACM certificate module is already created. To enable it, update `terraform/environments/dev/main.tf`:
+
+```hcl
+# Add ACM Certificate Module
+module "acm_certificate" {
+  source = "../../modules/acm-certificate"
+
+  providers = {
+    aws.us-east-1 = aws.us-east-1
+  }
+
+  environment               = "dev"
+  domain_name               = "kitaplatz-zentrale.de"
+  subject_alternative_names = ["www.kitaplatz-zentrale.de"]
+
+  # Set to false since DNS validation is in management account
+  auto_validate = false
+}
+```
+
+Apply Terraform:
+```bash
+cd terraform/environments/dev
+AWS_CONFIG_FILE=/Users/anthonysherrill/.aws/config-personal \
+AWS_PROFILE=kpz-dev \
+terraform init
+
+terraform apply -target=module.acm_certificate
+```
+
+### Step 2: Get DNS Validation Records
+
+After creating the certificate, get the validation records:
+
+```bash
+terraform output -json acm_certificate_validation_records
+```
+
+Or:
+```bash
+AWS_CONFIG_FILE=/Users/anthonysherrill/.aws/config-personal \
+AWS_PROFILE=kpz-dev \
+aws acm describe-certificate \
+  --certificate-arn <arn-from-terraform-output> \
+  --region us-east-1 \
+  --query 'Certificate.DomainValidationOptions[*].[ResourceRecord.Name,ResourceRecord.Type,ResourceRecord.Value]' \
+  --output table
+```
+
+**Example output**:
+```
+_1234567890abcdef.kitaplatz-zentrale.de.    CNAME    _abcdef1234567890.acm-validations.aws.
+_9876543210fedcba.www.kitaplatz-zentrale.de.    CNAME    _fedcba0987654321.acm-validations.aws.
+```
+
+### Step 3: Create Route53 Hosted Zone (Manual - management account)
+
+**In Management Account**:
+
+```bash
+AWS_CONFIG_FILE=/Users/anthonysherrill/.aws/config-personal \
+AWS_PROFILE=anthony-management \
+aws route53 create-hosted-zone \
+  --name kitaplatz-zentrale.de \
+  --caller-reference $(date +%s) \
+  --hosted-zone-config Comment="KPZ Production Domain"
+```
+
+**Save the Hosted Zone ID and Nameservers** from the output.
+
+### Step 4: Add DNS Validation Records (Manual - management account)
+
+Create a JSON file `dns-validation-records.json`:
+
+```json
+{
+  "Changes": [
+    {
+      "Action": "CREATE",
+      "ResourceRecordSet": {
+        "Name": "_1234567890abcdef.kitaplatz-zentrale.de.",
+        "Type": "CNAME",
+        "TTL": 300,
+        "ResourceRecords": [
+          {
+            "Value": "_abcdef1234567890.acm-validations.aws."
+          }
+        ]
+      }
+    },
+    {
+      "Action": "CREATE",
+      "ResourceRecordSet": {
+        "Name": "_9876543210fedcba.www.kitaplatz-zentrale.de.",
+        "Type": "CNAME",
+        "TTL": 300,
+        "ResourceRecords": [
+          {
+            "Value": "_fedcba0987654321.acm-validations.aws."
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+Apply the changes:
+```bash
+AWS_CONFIG_FILE=/Users/anthonysherrill/.aws/config-personal \
+AWS_PROFILE=anthony-management \
+aws route53 change-resource-record-sets \
+  --hosted-zone-id <zone-id-from-step-3> \
+  --change-batch file://dns-validation-records.json
+```
+
+### Step 5: Wait for Certificate Validation
+
+Monitor certificate status (in kpz-dev account):
+
+```bash
+AWS_CONFIG_FILE=/Users/anthonysherrill/.aws/config-personal \
+AWS_PROFILE=kpz-dev \
+aws acm describe-certificate \
+  --certificate-arn <certificate-arn> \
+  --region us-east-1 \
+  --query 'Certificate.Status' \
+  --output text
+```
+
+Status should change from `PENDING_VALIDATION` to `ISSUED` (usually within 5-30 minutes).
+
+### Step 6: Update CloudFront Distribution (Terraform - kpz-dev account)
+
+Update `terraform/environments/dev/main.tf`:
+
+```hcl
+# Update CloudFront Module
+module "cloudfront" {
+  source = "../../modules/cdn"
+
+  environment          = "dev"
+  s3_bucket_name       = module.s3_frontend.bucket_name
+  s3_website_endpoint  = module.s3_frontend.website_endpoint
+
+  # Add custom domain configuration
+  domain_name          = "kitaplatz-zentrale.de"
+  alternate_domain_names = ["www.kitaplatz-zentrale.de"]
+  acm_certificate_arn  = module.acm_certificate.certificate_arn
+}
+```
+
+Apply Terraform:
+```bash
+terraform apply
+```
+
+### Step 7: Create Route53 Records for CloudFront (Manual - management account)
+
+Get CloudFront domain name:
+```bash
+AWS_CONFIG_FILE=/Users/anthonysherrill/.aws/config-personal \
+AWS_PROFILE=kpz-dev \
+aws cloudfront get-distribution \
+  --id E2VPVOEHAHR6WE \
+  --query 'Distribution.DomainName' \
+  --output text
+```
+
+Create `cloudfront-alias-records.json`:
+
+```json
+{
+  "Changes": [
+    {
+      "Action": "CREATE",
+      "ResourceRecordSet": {
+        "Name": "kitaplatz-zentrale.de.",
+        "Type": "A",
+        "AliasTarget": {
+          "HostedZoneId": "Z2FDTNDATAQYW2",
+          "DNSName": "d2qust00jepj31.cloudfront.net.",
+          "EvaluateTargetHealth": false
+        }
+      }
+    },
+    {
+      "Action": "CREATE",
+      "ResourceRecordSet": {
+        "Name": "www.kitaplatz-zentrale.de.",
+        "Type": "A",
+        "AliasTarget": {
+          "HostedZoneId": "Z2FDTNDATAQYW2",
+          "DNSName": "d2qust00jepj31.cloudfront.net.",
+          "EvaluateTargetHealth": false
+        }
+      }
+    }
+  ]
+}
+```
+
+**Note**: `Z2FDTNDATAQYW2` is the fixed hosted zone ID for all CloudFront distributions.
+
+Apply the changes:
+```bash
+AWS_CONFIG_FILE=/Users/anthonysherrill/.aws/config-personal \
+AWS_PROFILE=anthony-management \
+aws route53 change-resource-record-sets \
+  --hosted-zone-id <zone-id> \
+  --change-batch file://cloudfront-alias-records.json
+```
+
+### Step 8: Update Domain Nameservers at Registrar
+
+Get nameservers from Route53:
+```bash
+AWS_CONFIG_FILE=/Users/anthonysherrill/.aws/config-personal \
+AWS_PROFILE=anthony-management \
+aws route53 get-hosted-zone \
+  --id <zone-id> \
+  --query 'DelegationSet.NameServers' \
+  --output table
+```
+
+Update your domain registrar to use these nameservers (typically 4 nameservers like `ns-123.awsdns-12.com`).
+
+**Note**: DNS propagation can take 24-48 hours.
+
+### Step 9: Verify Setup
+
+After nameserver propagation:
+
+```bash
+# Check DNS resolution
+dig kitaplatz-zentrale.de
+dig www.kitaplatz-zentrale.de
+
+# Test HTTPS
+curl -I https://kitaplatz-zentrale.de
+curl -I https://www.kitaplatz-zentrale.de
+
+# Check certificate
+openssl s_client -connect kitaplatz-zentrale.de:443 -servername kitaplatz-zentrale.de
+```
+
+**Expected results**:
+- Both domains resolve to CloudFront distribution
+- HTTPS works without certificate warnings
+- Certificate shows "kitaplatz-zentrale.de" with SAN "www.kitaplatz-zentrale.de"
+- HTTP redirects to HTTPS
+
+## Troubleshooting
+
+### Certificate Stuck in PENDING_VALIDATION
+
+**Cause**: DNS validation records not created or incorrect
+
+**Solution**:
+1. Verify records exist in Route53:
+   ```bash
+   aws route53 list-resource-record-sets --hosted-zone-id <zone-id>
+   ```
+2. Check if nameservers are correct
+3. Wait up to 30 minutes for propagation
+
+### CloudFront Returns 403 Forbidden
+
+**Cause**: S3 bucket policy doesn't allow CloudFront access
+
+**Solution**: Verify S3 bucket policy allows public read access
+
+### Domain Doesn't Resolve
+
+**Cause**: Nameserver propagation or DNS records not created
+
+**Solution**:
+1. Check nameservers at registrar
+2. Verify A records in Route53
+3. Wait for DNS propagation (24-48 hours)
+
+### SSL Certificate Error in Browser
+
+**Cause**: Certificate not attached to CloudFront or wrong domain
+
+**Solution**:
+1. Verify certificate is ISSUED: `aws acm describe-certificate`
+2. Check CloudFront viewer certificate configuration
+3. Ensure certificate is in us-east-1
+
+## Security Considerations
+
+- **TLS 1.2+**: Enforced via CloudFront viewer certificate configuration
+- **HSTS**: Consider adding HSTS headers via CloudFront Functions
+- **Certificate Expiration**: ACM auto-renews certificates if DNS validation records remain
+- **DNS Security**: Consider enabling DNSSEC on Route53
+
+## Cost Implications
+
+- **ACM Certificate**: Free
+- **Route53 Hosted Zone**: $0.50/month
+- **Route53 Queries**: $0.40 per million queries (first billion)
+- **CloudFront**: No additional cost for custom domain (existing distribution)
+
+## References
+
+- Issue: #125
+- CloudFront Distribution ID: `E2VPVOEHAHR6WE`
+- Management Account: `216360990183`
+- KPZ-Dev Account: `441104482452`
+- AWS Profile Config: `/Users/anthonysherrill/.aws/config-personal`

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -135,6 +135,22 @@ module "s3_lambda_artifacts" {
   environment = "dev"
 }
 
+# ACM Certificate - SSL/TLS for CloudFront
+module "acm_certificate" {
+  source = "../../modules/acm-certificate"
+
+  providers = {
+    aws.us-east-1 = aws.us-east-1
+  }
+
+  environment               = "dev"
+  domain_name               = "kitaplatz-zentrale.de"
+  subject_alternative_names = ["www.kitaplatz-zentrale.de"]
+
+  # Set to false since DNS validation is in management account
+  auto_validate = false
+}
+
 # CloudFront CDN - HTTPS support for frontend
 module "cloudfront" {
   source = "../../modules/cdn"
@@ -142,6 +158,11 @@ module "cloudfront" {
   environment          = "dev"
   s3_bucket_name       = module.s3_frontend.bucket_name
   s3_website_endpoint  = module.s3_frontend.website_endpoint
+
+  # Custom domain configuration
+  domain_name            = "kitaplatz-zentrale.de"
+  alternate_domain_names = ["www.kitaplatz-zentrale.de"]
+  acm_certificate_arn    = module.acm_certificate.certificate_arn
 }
 
 # EventBridge Schedule - Scraper (Daily at 2 AM UTC)

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -37,6 +37,22 @@ provider "aws" {
   }
 }
 
+# Additional provider for ACM certificates (CloudFront requires us-east-1)
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+  # profile is set via AWS_PROFILE environment variable for local development
+  # GitHub Actions uses OIDC authentication (no profile needed)
+
+  default_tags {
+    tags = {
+      Project     = "KPZ"
+      Environment = "dev"
+      ManagedBy   = "Terraform"
+    }
+  }
+}
+
 # IAM Module
 module "iam" {
   source = "../../modules/iam"

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -1,6 +1,6 @@
 # KPZ Development Environment
 # Deploys Lambda-based infrastructure to kpz-dev AWS account
-# CloudFront custom domain deployment after DNS propagation
+# CloudFront with dev.kitaplatz-zentrale.de custom domain
 
 terraform {
   required_version = "= 1.13.1"

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -1,6 +1,6 @@
 # KPZ Development Environment
 # Deploys Lambda-based infrastructure to kpz-dev AWS account
-# Trigger Terraform workflow to apply IAM role updates
+# CloudFront custom domain deployment after DNS propagation
 
 terraform {
   required_version = "= 1.13.1"

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -144,8 +144,8 @@ module "acm_certificate" {
   }
 
   environment               = "dev"
-  domain_name               = "kitaplatz-zentrale.de"
-  subject_alternative_names = ["www.kitaplatz-zentrale.de"]
+  domain_name               = "dev.kitaplatz-zentrale.de"
+  subject_alternative_names = []
 
   # Set to false since DNS validation is in management account
   auto_validate = false
@@ -159,9 +159,9 @@ module "cloudfront" {
   s3_bucket_name       = module.s3_frontend.bucket_name
   s3_website_endpoint  = module.s3_frontend.website_endpoint
 
-  # Custom domain configuration
-  domain_name            = "kitaplatz-zentrale.de"
-  alternate_domain_names = ["www.kitaplatz-zentrale.de"]
+  # Custom domain configuration - dev subdomain
+  domain_name            = "dev.kitaplatz-zentrale.de"
+  alternate_domain_names = []
   acm_certificate_arn    = module.acm_certificate.certificate_arn
 }
 

--- a/terraform/modules/acm-certificate/main.tf
+++ b/terraform/modules/acm-certificate/main.tf
@@ -1,0 +1,41 @@
+# ACM Certificate Module for CloudFront
+# Creates SSL/TLS certificate in us-east-1 (required for CloudFront)
+
+resource "aws_acm_certificate" "cloudfront" {
+  # CloudFront requires certificates to be in us-east-1
+  provider = aws.us-east-1
+
+  domain_name               = var.domain_name
+  subject_alternative_names = var.subject_alternative_names
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Name        = "kpz-${var.environment}-cloudfront-cert"
+    Environment = var.environment
+    ManagedBy   = "terraform"
+    Domain      = var.domain_name
+  }
+}
+
+# DNS validation records
+# Note: These records must be created in Route53 hosted zone
+# in the management account (216360990183)
+resource "aws_acm_certificate_validation" "cloudfront" {
+  # CloudFront requires certificates to be in us-east-1
+  provider = aws.us-east-1
+
+  certificate_arn = aws_acm_certificate.cloudfront.arn
+
+  # Only validate if auto_validate is enabled
+  # Set to false if DNS records need to be created manually in another account
+  count = var.auto_validate ? 1 : 0
+
+  # Validation will timeout if DNS records are not created
+  timeouts {
+    create = "45m"
+  }
+}

--- a/terraform/modules/acm-certificate/outputs.tf
+++ b/terraform/modules/acm-certificate/outputs.tf
@@ -1,0 +1,34 @@
+# ACM Certificate Module Outputs
+
+output "certificate_arn" {
+  description = "ARN of the ACM certificate"
+  value       = aws_acm_certificate.cloudfront.arn
+}
+
+output "certificate_domain_name" {
+  description = "Domain name of the certificate"
+  value       = aws_acm_certificate.cloudfront.domain_name
+}
+
+output "certificate_status" {
+  description = "Status of the certificate"
+  value       = aws_acm_certificate.cloudfront.status
+}
+
+output "domain_validation_options" {
+  description = "DNS validation records that must be created in Route53"
+  value       = aws_acm_certificate.cloudfront.domain_validation_options
+  sensitive   = false
+}
+
+output "validation_records" {
+  description = "Simplified DNS validation records for easier consumption"
+  value = [
+    for dvo in aws_acm_certificate.cloudfront.domain_validation_options : {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      value  = dvo.resource_record_value
+      domain = dvo.domain_name
+    }
+  ]
+}

--- a/terraform/modules/acm-certificate/variables.tf
+++ b/terraform/modules/acm-certificate/variables.tf
@@ -1,0 +1,23 @@
+# ACM Certificate Module Variables
+
+variable "environment" {
+  description = "Environment name (dev, prod)"
+  type        = string
+}
+
+variable "domain_name" {
+  description = "Primary domain name for the certificate"
+  type        = string
+}
+
+variable "subject_alternative_names" {
+  description = "Additional domain names to include in the certificate (e.g., www subdomain)"
+  type        = list(string)
+  default     = []
+}
+
+variable "auto_validate" {
+  description = "Automatically validate certificate. Set to false if DNS validation records are in a different AWS account."
+  type        = bool
+  default     = false
+}

--- a/terraform/modules/cdn/main.tf
+++ b/terraform/modules/cdn/main.tf
@@ -8,6 +8,9 @@ resource "aws_cloudfront_distribution" "frontend" {
   default_root_object = "index.html"
   price_class         = "PriceClass_100"  # US, Canada, Europe
 
+  # Custom domain names (aliases)
+  aliases = var.domain_name != null ? concat([var.domain_name], var.alternate_domain_names) : []
+
   origin {
     domain_name = var.s3_website_endpoint
     origin_id   = "S3-${var.s3_bucket_name}"
@@ -46,7 +49,11 @@ resource "aws_cloudfront_distribution" "frontend" {
   }
 
   viewer_certificate {
-    cloudfront_default_certificate = true
+    # Use custom certificate if domain_name is provided
+    cloudfront_default_certificate = var.domain_name == null ? true : false
+    acm_certificate_arn            = var.acm_certificate_arn
+    ssl_support_method             = var.domain_name != null ? "sni-only" : null
+    minimum_protocol_version       = var.domain_name != null ? "TLSv1.2_2021" : null
   }
 
   # Custom error response for SPA routing

--- a/terraform/modules/cdn/variables.tf
+++ b/terraform/modules/cdn/variables.tf
@@ -14,3 +14,21 @@ variable "s3_website_endpoint" {
   description = "S3 website endpoint (without http://)"
   type        = string
 }
+
+variable "domain_name" {
+  description = "Custom domain name for CloudFront distribution (e.g., kitaplatz-zentrale.de). Leave empty to use default CloudFront domain."
+  type        = string
+  default     = null
+}
+
+variable "alternate_domain_names" {
+  description = "Additional domain names (e.g., www.kitaplatz-zentrale.de). Only used if domain_name is set."
+  type        = list(string)
+  default     = []
+}
+
+variable "acm_certificate_arn" {
+  description = "ARN of ACM certificate in us-east-1. Required if domain_name is set."
+  type        = string
+  default     = null
+}

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -218,6 +218,20 @@ resource "aws_iam_role_policy" "github_actions_terraform_infra" {
         ]
         Resource = "*"
       },
+      # ACM permissions (required for CloudFront certificates in us-east-1)
+      {
+        Effect = "Allow"
+        Action = [
+          "acm:RequestCertificate",
+          "acm:DescribeCertificate",
+          "acm:DeleteCertificate",
+          "acm:ListCertificates",
+          "acm:AddTagsToCertificate",
+          "acm:RemoveTagsFromCertificate",
+          "acm:ListTagsForCertificate"
+        ]
+        Resource = "*"
+      },
       # CloudWatch Logs permissions
       {
         Effect = "Allow"


### PR DESCRIPTION
## Summary

Successfully configured HTTPS custom domain for the dev environment using AWS ACM, CloudFront, and Route53.

## Changes

### Infrastructure
- Added ACM certificate module for SSL/TLS certificates in us-east-1 (required by CloudFront)
- Updated CloudFront CDN module to support custom domains with ACM certificates
- Configured dev environment with `dev.kitaplatz-zentrale.de` subdomain
- Reserved apex domain (`kitaplatz-zentrale.de`) and www subdomain for production

### DNS Configuration
- Created Route53 hosted zone in management account (Z06036888YC8QS4UPMH0)
- Added DNS validation CNAME records for ACM certificate validation
- Created ALIAS A record pointing dev.kitaplatz-zentrale.de to CloudFront distribution

### Workflow Improvements
- Split Terraform workflow into separate plan (PR) and apply (merge) jobs
- Enhanced PR comments to show terraform plan output
- Added ACM permissions to GitHub Actions IAM role

### Scraper Lambda
- Added scraper Lambda function for daily Kita data collection
- Configured EventBridge scheduler for daily execution at 2 AM UTC

## Live URLs

- **Dev**: https://dev.kitaplatz-zentrale.de ✅
- **Production**: Reserved for future deployment (apex domain)

## Testing

✅ HTTPS certificate validated and working  
✅ CloudFront distribution serving content with custom domain  
✅ HTTP/2 enabled  
✅ SSL certificate issued by Amazon, valid until Feb 2, 2027  

## Notes

- Terraform modules are parameterized and reusable for production deployment
- Production will use apex domain (`kitaplatz-zentrale.de`) and www subdomain
- All infrastructure changes are managed via Terraform IaC

Closes #125