### PR TITLE
feat: Add HTTPS custom domain support for dev environment

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -1,6 +1,6 @@
 # KPZ Development Environment
 # Deploys Lambda-based infrastructure to kpz-dev AWS account
-# CloudFront custom domain deployment after DNS propagation
+# CloudFront with dev.kitaplatz-zentrale.de custom domain
 
 terraform {
   required_version = "= 1.13.1"

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -1,6 +1,6 @@
 # KPZ Development Environment
 # Deploys Lambda-based infrastructure to kpz-dev AWS account
-# Trigger Terraform workflow to apply IAM role updates
+# CloudFront custom domain deployment after DNS propagation
 
 terraform {
   required_version = "= 1.13.1"

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -144,8 +144,8 @@ module "acm_certificate" {
   }
 
   environment               = "dev"
-  domain_name               = "kitaplatz-zentrale.de"
-  subject_alternative_names = ["www.kitaplatz-zentrale.de"]
+  domain_name               = "dev.kitaplatz-zentrale.de"
+  subject_alternative_names = []
 
   # Set to false since DNS validation is in management account
   auto_validate = false
@@ -159,9 +159,9 @@ module "cloudfront" {
   s3_bucket_name       = module.s3_frontend.bucket_name
   s3_website_endpoint  = module.s3_frontend.website_endpoint
 
-  # Custom domain configuration
-  domain_name            = "kitaplatz-zentrale.de"
-  alternate_domain_names = ["www.kitaplatz-zentrale.de"]
+  # Custom domain configuration - dev subdomain
+  domain_name            = "dev.kitaplatz-zentrale.de"
+  alternate_domain_names = []
   acm_certificate_arn    = module.acm_certificate.certificate_arn
 }
 

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -218,6 +218,20 @@ resource "aws_iam_role_policy" "github_actions_terraform_infra" {
         ]
         Resource = "*"
       },
+      # ACM permissions (required for CloudFront certificates in us-east-1)
+      {
+        Effect = "Allow"
+        Action = [
+          "acm:RequestCertificate",
+          "acm:DescribeCertificate",
+          "acm:DeleteCertificate",
+          "acm:ListCertificates",
+          "acm:AddTagsToCertificate",
+          "acm:RemoveTagsFromCertificate",
+          "acm:ListTagsForCertificate"
+        ]
+        Resource = "*"
+      },
       # CloudWatch Logs permissions
       {
         Effect = "Allow"


### PR DESCRIPTION
## Summary

Successfully configured HTTPS custom domain for the dev environment using AWS ACM, CloudFront, and Route53.

## Changes

### Infrastructure
- Added ACM certificate module for SSL/TLS certificates in us-east-1 (required by CloudFront)
- Updated CloudFront CDN module to support custom domains with ACM certificates
- Configured dev environment with `dev.kitaplatz-zentrale.de` subdomain
- Reserved apex domain (`kitaplatz-zentrale.de`) and www subdomain for production

### DNS Configuration
- Created Route53 hosted zone in management account (Z06036888YC8QS4UPMH0)
- Added DNS validation CNAME records for ACM certificate validation
- Created ALIAS A record pointing dev.kitaplatz-zentrale.de to CloudFront distribution

### Workflow Improvements
- Split Terraform workflow into separate plan (PR) and apply (merge) jobs
- Enhanced PR comments to show terraform plan output
- Added ACM permissions to GitHub Actions IAM role

## Live URLs

- **Dev**: https://dev.kitaplatz-zentrale.de ✅
- **Production**: Reserved for future deployment (apex domain)

## Testing

✅ HTTPS certificate validated and working  
✅ CloudFront distribution serving content with custom domain  
✅ HTTP/2 enabled  
✅ SSL certificate issued by Amazon, valid until Feb 2, 2027  
✅ Terraform validation passed

## Technical Details

**Certificate ARN**: `arn:aws:acm:us-east-1:441104482452:certificate/ffeb2f18-a244-48bf-b14d-5c230124de18`  
**CloudFront Distribution**: `E2VPVOEHAHR6WE`  
**Route53 Hosted Zone**: `Z06036888YC8QS4UPMH0`

## Notes

- Terraform modules are parameterized and reusable for production deployment
- Production will use apex domain (`kitaplatz-zentrale.de`) and www subdomain
- All infrastructure changes are managed via Terraform IaC
- Dev environment uses subdomain to avoid CNAME conflicts and reserve apex for production

Closes #125