### PR TITLE
fix: Resolve Terraform validation warnings (#133)

### DIFF
--- a/terraform/modules/acm-certificate/main.tf
+++ b/terraform/modules/acm-certificate/main.tf
@@ -1,3 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "~> 5.0"
+      configuration_aliases = [aws.us-east-1]
+    }
+  }
+}
+
 # ACM Certificate Module for CloudFront
 # Creates SSL/TLS certificate in us-east-1 (required for CloudFront)
 

--- a/terraform/modules/compute/lambda/main.tf
+++ b/terraform/modules/compute/lambda/main.tf
@@ -44,8 +44,7 @@ resource "aws_lambda_function" "function" {
       filename,
       source_code_hash,
       s3_key,
-      s3_object_version,
-      last_modified
+      s3_object_version
     ]
   }
 }

--- a/terraform/modules/storage/lambda-artifacts/main.tf
+++ b/terraform/modules/storage/lambda-artifacts/main.tf
@@ -50,6 +50,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "lambda_artifacts" {
     id     = "cleanup-old-versions"
     status = "Enabled"
 
+    filter {}
+
     noncurrent_version_expiration {
       noncurrent_days = 30
     }


### PR DESCRIPTION
Fixes #133

## Summary
Resolves all three Terraform validation warnings to ensure clean validation output.

## Changes

### 1. ACM Certificate Module
- **File**: `terraform/modules/acm-certificate/main.tf`
- **Fix**: Added `required_providers` block with `aws.us-east-1` configuration alias
- **Why**: The module uses `provider = aws.us-east-1` but didn't declare the alias

### 2. Lambda Module
- **File**: `terraform/modules/compute/lambda/main.tf`
- **Fix**: Removed `last_modified` from `ignore_changes` list
- **Why**: `last_modified` is a provider-managed attribute with no configured value, making it redundant in `ignore_changes`

### 3. S3 Lifecycle Configuration
- **File**: `terraform/modules/storage/lambda-artifacts/main.tf`
- **Fix**: Added empty `filter {}` block to lifecycle rule
- **Why**: AWS provider now requires either `filter` or `prefix` for lifecycle rules (empty filter applies to all objects)

## Verification

✅ `terraform validate` passes with **zero warnings**
✅ These are purely syntactic fixes - no infrastructure changes
✅ Follows AWS provider best practices

## Before
```
Success! The configuration is valid, but there were some validation warnings as shown above.
```

## After
```
Success! The configuration is valid.
```

## Risk Assessment
**Risk**: LOW - No functional changes, only metadata/syntax improvements